### PR TITLE
fix(boot): get 3 node cluster to come up clean (WIP)

### DIFF
--- a/manifests/riak-bootstrap-pod.yaml
+++ b/manifests/riak-bootstrap-pod.yaml
@@ -9,7 +9,8 @@ metadata:
 spec:
   containers:
     - name: riak
-      image: deis/riak:0.1.0
+      image: quay.io/deisci/riak:v2-beta
+      imagePullPolicy: Always
       env:
         - name:  RIAK_INET_DIST_MIN
           value: "6001"

--- a/manifests/riak-rc.yaml
+++ b/manifests/riak-rc.yaml
@@ -16,7 +16,8 @@ spec:
     spec:
       containers:
         - name: riak
-          image: deis/riak:0.1.0
+          image: quay.io/deisci/riak:v2-beta
+          imagePullPolicy: Always
           env:
             - name:  RIAK_INET_DIST_MIN
               value: "6001"

--- a/manifests/riak-rc.yaml
+++ b/manifests/riak-rc.yaml
@@ -23,6 +23,8 @@ spec:
               value: "6001"
             - name:  RIAK_INET_DIST_MAX
               value: "6001"
+            - name: RIAK_JOIN_WAIT_TIME
+              value: "5"
           ports:
             - containerPort: 4369
             - containerPort: 6001

--- a/rootfs/bin/boot
+++ b/rootfs/bin/boot
@@ -4,6 +4,10 @@ RIAK_BACKEND=${RIAK_BACKEND:-bitcask}
 
 IP_ADDRESS=$(ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
 
+if [ -z "$RIAK_JOIN_WAIT_TIME" ]; then
+  RIAK_JOIN_WAIT_TIME=5
+fi
+
 # Ensure correct ownership and permissions on volumes
 chown riak:riak /var/lib/riak /var/log/riak
 chmod 755 /var/lib/riak /var/log/riak
@@ -36,7 +40,9 @@ if ! $(env | grep -q "RIAK_MASTER=1"); then
   DISCOVERY_HOSTS="$(host deis-riak-discovery)"
   echo "Discovery Hosts: ${DISCOVERY_HOSTS}"
   CLUSTER_IP="$(host deis-riak-discovery | head -n 1 | awk '{print $4}')"
-  echo "joining node with ${CLUSTER_IP}"
+  echo "Waiting ${RIAK_JOIN_WAIT_TIME} seconds before attempting to join cluster"
+  sleep $RIAK_JOIN_WAIT_TIME
+  echo "Joining to cluster with IP ${CLUSTER_IP}"
   riak-admin cluster join "riak@${CLUSTER_IP}"
 fi
 

--- a/rootfs/bin/boot
+++ b/rootfs/bin/boot
@@ -33,9 +33,11 @@ echo "started"
 
 # Connect to the master if we're a slave
 if ! $(env | grep -q "RIAK_MASTER=1"); then
+  DISCOVERY_HOSTS="$(host deis-riak-discovery)"
+  echo "Discovery Hosts: ${DISCOVERY_HOSTS}"
   CLUSTER_IP="$(host deis-riak-discovery | head -n 1 | awk '{print $4}')"
   echo "joining node with ${CLUSTER_IP}"
-  riak-admin cluster join "riak@$CLUSTER_IP"
+  riak-admin cluster join "riak@${CLUSTER_IP}"
 fi
 
 wait

--- a/rootfs/bin/boot
+++ b/rootfs/bin/boot
@@ -22,15 +22,19 @@ if env | grep -q "RIAK_INET_DIST_MIN"; then
   echo "erlang.distribution.port_range.maximum = ${RIAK_INET_DIST_MAX}" >> /etc/riak/riak.conf
 fi
 
+echo "Starting Riak..."
 # Start Riak
 "$(ls -d /usr/lib/riak/erts*)/bin/run_erl" "/tmp/riak" "/var/log/riak" "exec /usr/sbin/riak console" &
 
 # wait for riak to come up locally
 sleep 5
 
+echo "started"
+
 # Connect to the master if we're a slave
 if ! $(env | grep -q "RIAK_MASTER=1"); then
   CLUSTER_IP="$(host deis-riak-discovery | head -n 1 | awk '{print $4}')"
+  echo "joining node with ${CLUSTER_IP}"
   riak-admin cluster join "riak@$CLUSTER_IP"
 fi
 


### PR DESCRIPTION
Also sets `imagePullPolicy: Always` on all manifests and configures them to pull from `quay.io/deisci/riak:v2-beta`.

Current cluster startup status is:
- Non-bootstrap pods sleep for a configurable amount of time, to attempt to wait until the bootstrap pod is ready. This behavior results in a non-deterministic startup procedure, but I believe it's a good first pass. #5 details a much better, deterministic solution.
- ~~One of the two non-bootstrap pods come up with `Failed: This node is already a member of a cluster`~~
- ~~The other of the two comes up successfully (`Success: staged join request for 'riak@10.168.2.28' to 'riak@10.168.0.37'`)~~
- ~~The bootstrap node starts fine (as expected)~~
