### PR TITLE
ref(travis): use travis deploy pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,8 @@ services:
 script:
   - make bootstrap
   - make test
+deploy:
+  provider: script
+  script: _scripts/deploy.sh
+  on:
+    branch: master

--- a/Makefile
+++ b/Makefile
@@ -50,12 +50,8 @@ build:
 test:
 	${DEV_ENV_CMD} go test -race ${TEST_PACKAGES}
 
-# For cases where we're building from local
-# We also alter the RC file to set the image name.
 docker-build:
 	docker build --rm -t ${IMAGE} rootfs
-	perl -pi -e "s|[a-z0-9.:]+\/deis\/${SHORT_NAME}:[0-9a-z-.]+|${IMAGE}|g" ${BOOTSTRAP}
-	perl -pi -e "s|[a-z0-9.:]+\/deis\/${SHORT_NAME}:[0-9a-z-.]+|${IMAGE}|g" ${RC}
 
 # Push to a registry that Kubernetes can access.
 docker-push:

--- a/_scripts/deploy.sh
+++ b/_scripts/deploy.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Build and push Docker images to Docker Hub and quay.io.
+#
+
+cd "$(dirname "$0")" || exit 1
+
+cd ..
+
+export IMAGE_PREFIX=deis VERSION=latest
+docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+DEIS_REGISTRY='' make
+docker login -e="$QUAY_EMAIL" -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io
+DEIS_REGISTRY=quay.io/ make


### PR DESCRIPTION
Building the image requires compiling the Go binaries and copying
them into the root filesystem, which is something Docker's automated
build system does not have the ability to do. Instead, leveraging
Travis' deploy system will allow us to build the image as we see
fit.

closes #28 
closes helm/charts#68
closes helm/charts#69
closes helm/charts#70

TODO:
- [x] disable automated builds on DockerHub
- [x] populate deis/riak repo on travis with DOCKER_EMAIL, DOCKER_USERNAME, DOCKER_PASSWORD, QUAY_EMAIL, QUAY_USERNAME, and QUAY_PASSWORD
