### PR TITLE
Support for multiple container network interfaces

### DIFF
--- a/rootfs/bin/start_riak
+++ b/rootfs/bin/start_riak
@@ -2,7 +2,7 @@
 
 RIAK_BACKEND=${RIAK_BACKEND:-bitcask}
 
-IP_ADDRESS=$(ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
+IP_ADDRESS=$(ip -o -4 route | awk '/default v/{DEV=$5}{if($3 == DEV && $(NF -1) == "src" )print $NF}')
 
 # Ensure correct ownership and permissions on volumes
 chown riak:riak /var/lib/riak /var/log/riak


### PR DESCRIPTION
Hi, this change adds support for multiple container network interfaces, as of Docker 1.12 - also removes the extra call to split, as that can be handled directly within AWK http://stackoverflow.com/a/39393229/7076248